### PR TITLE
2.0 Rewrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . /app/
 
 RUN composer dump-autoload --optimize --classmap-authoritative
 
-FROM php:7.3-cli as base
+FROM php:8.1-cli as base
 
 # Install PECL and PEAR extensions
 RUN pecl install xdebug

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ specified in config), and appended to every log context.
 
 1. Run `composer require lukaszaleckas/laravel-correlation-id`
 2. Publish `correlation_id.php` config: `php artisan vendor:publish --tag=laravel-correlation-id`
-3. Add `LaravelCorrelationId\Http\Middleware\CorrelationIdMiddleware` middleware to your 
-Http kernel.
-4. (optional) Extend your jobs from `LaravelCorrelationId\Jobs\Contracts\AbstractCorrelatableJob`
+3. (optional) Add `LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId` trait to your jobs
 if you want correlation id to be automatically saved on job dispatch and recalled before
 it is handled / processed.
 
@@ -22,23 +20,12 @@ Firstly, you should inject `LaravelCorrelationId\CorrelationIdService` service.
 
 Current correlation id can be accessed by calling service's `getCurrentCorrelationId` method.
 
+This package extends Laravel's default `Dispatcher` class so that the correlation ID could be set before the job is dispatched, and recalled before it is processed.
+
+This package adds `LaravelCorrelationId\Http\Middleware\CorrelationIdMiddleware` middleware to the global middleware stack by default.
+If you want to add the middleware to specific routes/groups on your own, you can disable this behaviour by setting `CORRELATION_ID_INCLUDE_ROUTE_MIDDLEWARE` environment variable to `false`.
+
 ## Note on jobs
-
-Correlation id is automatically saved (protected variable `$correlationId` is set) on job dispatch
-and recalled (set in `CorrelationIdService` scoped singleton) using job middleware. If your job is already
-using middleware(s), you should remember to merge them with `AbstractCorrelatableJob` ones:
-
-```php
-    public function middleware(): array
-    {
-        return array_merge(
-            parent::middleware(),
-            [
-                //your middleware
-            ]
-        );
-    }
-```
 
 If you are mocking Laravel's `Dispatcher::class` in your tests, you should update them
 to mock this package's `JobDispatcher` class:
@@ -46,3 +33,23 @@ to mock this package's `JobDispatcher` class:
 ```php
     Mockery::mock(JobDispatcher::class)->shouldReceive('something')->...
 ```
+
+## Note on Guzzle
+
+If you are using Guzzle and want to pass the correlation ID from one application to another, you will find the `\LaravelCorrelationId\Utils\GuzzleUtils\` class useful.
+It exposes 2 methods:
+* `getHandlerStack` for use with `GuzzleHttp\Client`'s `handler` option
+* `getMiddleware` for use with Laravel's HTTP client facade.
+
+Using these methods will ensure that the client passes the correlation ID header and value to another application.
+
+## Upgrading
+
+### From 1.x to 2.x
+
+These versions should not have any breaking changes.
+However, version `2.x` deprecates the `\LaravelCorrelationId\Jobs\Middleware\RecallCorrelationIdMiddleware` and `\LaravelCorrelationId\Jobs\Contracts\AbstractCorrelatableJob` classes.
+
+If you still use them, please consider upgrading to use the new `\LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId` job trait.
+
+Version 2.x also automatically adds the `\LaravelCorrelationId\Http\Middleware\CorrelationIdMiddleware` as a global middleware, so you no longer have to manually do that.

--- a/composer.json
+++ b/composer.json
@@ -13,22 +13,23 @@
     },
     "config": {
         "platform": {
-            "php": "7.3.30"
+            "php": "8.1"
         }
     },
     "require": {
-        "php": "^7.3|^8.0",
-        "laravel/framework": "^8.49|^9.0|^10.0"
+        "php": "^8.1",
+        "laravel/framework": "^9.0|^10.0",
+        "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {
         "fakerphp/faker": "^1.15",
         "mockery/mockery": "^1.4",
-        "phpstan/phpstan-mockery": "^0.12.14",
+        "phpstan/phpstan-mockery": "^1.1.2",
         "phpunit/phpunit": "^9.5",
         "slevomat/coding-standard": "^6.4",
         "squizlabs/php_codesniffer": "^3.6",
-        "nunomaduro/larastan": "^0.7.12",
-        "orchestra/testbench": "^6.20"
+        "larastan/larastan": "^2.8.1",
+        "orchestra/testbench": "^v7.40.1"
     },
     "extra": {
         "laravel": {

--- a/docker/xdebug.ini
+++ b/docker/xdebug.ini
@@ -1,6 +1,5 @@
 [Xdebug]
-xdebug.remote_enable = 1
-xdebug.remote_connect_back = 0
+xdebug.mode = debug
 xdebug.idekey = "PHPSTORM"
 xdebug.port = 9000
-xdebug.remote_autostart=1
+xdebug.start_with_request = yes

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
     - ./vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:

--- a/src/JobDispatcher.php
+++ b/src/JobDispatcher.php
@@ -4,7 +4,8 @@ namespace LaravelCorrelationId;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use LaravelCorrelationId\Jobs\Contracts\AbstractCorrelatableJob;
+use LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId;
+use LaravelCorrelationId\Utils\Helpers;
 
 class JobDispatcher extends Dispatcher
 {
@@ -21,7 +22,7 @@ class JobDispatcher extends Dispatcher
      * @return mixed
      * @throws BindingResolutionException
      */
-    public function dispatchToQueue($command)
+    public function dispatchToQueue(mixed $command): mixed
     {
         $this->handleCorrelationId($command);
 
@@ -34,7 +35,7 @@ class JobDispatcher extends Dispatcher
      * @return mixed
      * @throws BindingResolutionException
      */
-    public function dispatchNow($command, $handler = null)
+    public function dispatchNow(mixed $command, mixed $handler = null): mixed
     {
         $this->handleCorrelationId($command);
 
@@ -46,9 +47,9 @@ class JobDispatcher extends Dispatcher
      * @return void
      * @throws BindingResolutionException
      */
-    private function handleCorrelationId($command): void
+    private function handleCorrelationId(mixed $command): void
     {
-        if ($command instanceof AbstractCorrelatableJob) {
+        if (Helpers::hasTrait($command, RecallsCorrelationId::class)) {
             $command->setCorrelationId(
                 $this->getCorrelationIdService()->getCurrentCorrelationId()
             );

--- a/src/Jobs/Contracts/AbstractCorrelatableJob.php
+++ b/src/Jobs/Contracts/AbstractCorrelatableJob.php
@@ -2,37 +2,12 @@
 
 namespace LaravelCorrelationId\Jobs\Contracts;
 
-use LaravelCorrelationId\Jobs\Middleware\RecallCorrelationIdMiddleware;
+use LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId;
 
+/**
+ * @deprecated Add the RecallsCorrelationId trait to your job instead.
+ */
 abstract class AbstractCorrelatableJob
 {
-    /** @var string|null */
-    protected $correlationId = null;
-
-    /**
-     * @return string[]
-     */
-    public function middleware(): array
-    {
-        return [
-            RecallCorrelationIdMiddleware::class
-        ];
-    }
-
-    /**
-     * @param string|null $correlationId
-     * @return void
-     */
-    public function setCorrelationId(?string $correlationId): void
-    {
-        $this->correlationId = $correlationId;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getCorrelationId(): ?string
-    {
-        return $this->correlationId;
-    }
+    use RecallsCorrelationId;
 }

--- a/src/Jobs/Middleware/RecallCorrelationIdMiddleware.php
+++ b/src/Jobs/Middleware/RecallCorrelationIdMiddleware.php
@@ -5,10 +5,13 @@ namespace LaravelCorrelationId\Jobs\Middleware;
 use LaravelCorrelationId\CorrelationIdService;
 use LaravelCorrelationId\Jobs\Contracts\AbstractCorrelatableJob;
 
+/**
+ * @deprecated This logic is handled by the event listener in the package's service provider.
+ */
 class RecallCorrelationIdMiddleware
 {
     /** @var CorrelationIdService */
-    private $correlationIdService;
+    private CorrelationIdService $correlationIdService;
 
     /**
      * @param CorrelationIdService $correlationIdService
@@ -23,7 +26,7 @@ class RecallCorrelationIdMiddleware
      * @param mixed $next
      * @return mixed
      */
-    public function handle($job, $next)
+    public function handle(mixed $job, mixed $next): mixed
     {
         if ($job instanceof AbstractCorrelatableJob) {
             $this->correlationIdService->setCurrentCorrelationId(

--- a/src/Jobs/Traits/RecallsCorrelationId.php
+++ b/src/Jobs/Traits/RecallsCorrelationId.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LaravelCorrelationId\Jobs\Traits;
+
+trait RecallsCorrelationId
+{
+    /**
+     * @var string|null
+     */
+    protected ?string $correlationId = null;
+
+    /**
+     * @param string|null $correlationId
+     * @return void
+     */
+    public function setCorrelationId(?string $correlationId): void
+    {
+        $this->correlationId = $correlationId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCorrelationId(): ?string
+    {
+        return $this->correlationId;
+    }
+}

--- a/src/Listeners/SetCorrelationId.php
+++ b/src/Listeners/SetCorrelationId.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LaravelCorrelationId\Listeners;
+
+use Illuminate\Queue\Events\JobProcessing;
+use LaravelCorrelationId\CorrelationIdService;
+use LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId;
+use LaravelCorrelationId\Utils\Helpers;
+
+class SetCorrelationId
+{
+    /**
+     * @param CorrelationIdService $correlationIdService
+     */
+    public function __construct(
+        protected CorrelationIdService $correlationIdService
+    ) {
+    }
+
+    /**
+     * @param JobProcessing $event
+     * @return void
+     */
+    public function handle(JobProcessing $event): void
+    {
+        if (!Helpers::hasTrait($event->job->resolveName(), RecallsCorrelationId::class)) {
+            return;
+        }
+
+        $command = unserialize($event->job->payload()['data']['command']);
+
+        $this->correlationIdService->setCurrentCorrelationId(
+            $command->getCorrelationId()
+        );
+    }
+}

--- a/src/Providers/CorrelationIdServiceProvider.php
+++ b/src/Providers/CorrelationIdServiceProvider.php
@@ -3,20 +3,28 @@
 namespace LaravelCorrelationId\Providers;
 
 use Illuminate\Bus\Dispatcher;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider;
 use LaravelCorrelationId\CorrelationIdService;
+use LaravelCorrelationId\Http\Middleware\CorrelationIdMiddleware;
 use LaravelCorrelationId\JobDispatcher;
+use LaravelCorrelationId\Listeners\SetCorrelationId;
 
 class CorrelationIdServiceProvider extends ServiceProvider
 {
     /**
+     * @param Kernel $kernel
      * @return void
      */
-    public function boot(): void
+    public function boot(Kernel $kernel): void
     {
         $this->publishes([
             __DIR__ . '/../config/correlation_id.php' => config_path('correlation_id.php'),
         ], 'laravel-correlation-id');
+
+        $this->pushGlobalMiddleware($kernel);
+        $this->prepareEventListeners();
     }
 
     /**
@@ -31,5 +39,34 @@ class CorrelationIdServiceProvider extends ServiceProvider
                 return new JobDispatcher($service);
             }
         );
+    }
+
+    /**
+     * @param Kernel $kernel
+     * @return void
+     */
+    private function pushGlobalMiddleware(Kernel $kernel): void
+    {
+        if (!$this->shouldIncludeRouteMiddleware()) {
+            return;
+        }
+
+        $kernel->pushMiddleware(CorrelationIdMiddleware::class);
+    }
+
+    /**
+     * @return void
+     */
+    private function prepareEventListeners(): void
+    {
+        Queue::before(SetCorrelationId::class);
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldIncludeRouteMiddleware(): bool
+    {
+        return config('correlation_id.include_route_middleware') ?? true;
     }
 }

--- a/src/Utils/GuzzleUtils.php
+++ b/src/Utils/GuzzleUtils.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace LaravelCorrelationId\Utils;
+
+use Closure;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Illuminate\Support\Facades\App;
+use LaravelCorrelationId\CorrelationIdService;
+use Psr\Http\Message\RequestInterface;
+
+class GuzzleUtils
+{
+    /**
+     * @return HandlerStack
+     */
+    public static function getHandlerStack(): HandlerStack
+    {
+        $stack = HandlerStack::create();
+
+        $stack->push(Middleware::mapRequest(self::getMiddleware()), 'correlation_id');
+
+        return $stack;
+    }
+
+    /**
+     * @return Closure
+     */
+    public static function getMiddleware(): Closure
+    {
+        $correlationIdService = App::make(CorrelationIdService::class);
+
+        return fn(RequestInterface $request) => $request->withHeader(
+            $correlationIdService->getHttpHeaderName(),
+            $correlationIdService->getCurrentCorrelationId()
+        );
+    }
+}

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaravelCorrelationId\Utils;
+
+class Helpers
+{
+    /**
+     * @param object|class-string $class
+     * @param class-string        $trait
+     * @return bool
+     */
+    public static function hasTrait(object|string $class, string $trait): bool
+    {
+        return in_array($trait, class_uses_recursive($class));
+    }
+}

--- a/src/config/correlation_id.php
+++ b/src/config/correlation_id.php
@@ -9,11 +9,22 @@ return [
      *
      * In case of response: it will include this header with correlation ID.
      */
-    'header_name'     => env('CORRELATION_ID_HEADER_NAME', 'X-CORRELATION-ID'),
+    'header_name'              => env('CORRELATION_ID_HEADER_NAME', 'X-CORRELATION-ID'),
 
     /*
      * Log's context array key name. Correlation ID with this name will be appended to all logs'
      * context.
      */
-    'log_context_key' => env('CORRELATION_ID_LOG_CONTEXT_KEY', 'correlation_id')
+    'log_context_key'          => env('CORRELATION_ID_LOG_CONTEXT_KEY', 'correlation_id'),
+
+    /*
+     * Whether to include route middlewares globally by default.
+     *
+     * If set to true, the CorrelationIdMiddleware will be included in the global middlewares
+     * by the CorrelationIdServiceProvider.
+     *
+     * You should set this to false if you only want the correlation ID header to be handled
+     * only on some requests
+     */
+    'include_route_middleware' => env('CORRELATION_ID_INCLUDE_ROUTE_MIDDLEWARE', true),
 ];

--- a/tests/Feature/Jobs/Contracts/AbstractCorrelatableJobTest.php
+++ b/tests/Feature/Jobs/Contracts/AbstractCorrelatableJobTest.php
@@ -3,7 +3,7 @@
 namespace LaravelCorrelationId\Tests\Feature\Jobs\Contracts;
 
 use LaravelCorrelationId\Jobs\Contracts\AbstractCorrelatableJob;
-use LaravelCorrelationId\Jobs\Middleware\RecallCorrelationIdMiddleware;
+use LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId;
 use LaravelCorrelationId\Tests\AbstractTest;
 
 class AbstractCorrelatableJobTest extends AbstractTest
@@ -11,14 +11,14 @@ class AbstractCorrelatableJobTest extends AbstractTest
     /**
      * @return void
      */
-    public function testIncludesMiddleware(): void
+    public function testIncludesTrait(): void
     {
         $job = new class extends AbstractCorrelatableJob{
         };
 
-        self::assertEquals(
-            [RecallCorrelationIdMiddleware::class],
-            $job->middleware()
+        self::assertContains(
+            RecallsCorrelationId::class,
+            class_uses_recursive($job)
         );
     }
 }

--- a/tests/Feature/Listeners/SetCorrelationIdTest.php
+++ b/tests/Feature/Listeners/SetCorrelationIdTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace LaravelCorrelationId\Tests\Feature\Listeners;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Event;
+use LaravelCorrelationId\CorrelationIdService;
+use LaravelCorrelationId\Listeners\SetCorrelationId;
+use LaravelCorrelationId\Tests\AbstractTest;
+use LaravelCorrelationId\Tests\Stubs\CommandWithTraitStub;
+use Mockery\MockInterface;
+
+class SetCorrelationIdTest extends AbstractTest
+{
+    use WithFaker;
+
+    /**
+     * @return void
+     */
+    public function testListensToJobProcessingEvent(): void
+    {
+        Event::fake(JobProcessing::class);
+
+        Event::assertListening(
+            JobProcessing::class,
+            SetCorrelationId::class
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testReturnsEarlyWhenJobsDontHaveTrait(): void
+    {
+        /** @var MockInterface|Job $jobMock */
+        $jobMock = $this->mock(Job::class);
+        $command = new class {
+            // ...
+        };
+
+        $jobMock->shouldReceive('resolveName')
+            ->once()
+            ->andReturn($command);
+
+        $this->runListener($jobMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetsCorrelationIdWhenJobsHaveTrait()
+    {
+        /** @var MockInterface|Job $jobMock */
+        $jobMock       = $this->mock(Job::class);
+        $correlationId = $this->faker->uuid;
+        $command       = new CommandWithTraitStub();
+
+        $command->setCorrelationId($correlationId);
+
+        $jobMock->shouldReceive('resolveName')
+            ->once()
+            ->andReturn($command);
+
+        $jobMock->shouldReceive('payload')
+            ->once()
+            ->andReturn([
+                'data' => [
+                    'command' => serialize($command),
+                ],
+            ]);
+
+        $this->runListener($jobMock);
+
+        $this->assertSame(
+            $correlationId,
+            App::make(CorrelationIdService::class)->getCurrentCorrelationId()
+        );
+    }
+
+    /**
+     * @param MockInterface|Job $jobMock
+     * @return void
+     */
+    private function runListener(MockInterface|Job $jobMock): void
+    {
+        $event = new JobProcessing(
+            $this->faker->word,
+            $jobMock,
+        );
+
+        $listener = App::make(SetCorrelationId::class);
+        $listener->handle($event);
+    }
+}

--- a/tests/Feature/Utils/GuzzleUtilsTest.php
+++ b/tests/Feature/Utils/GuzzleUtilsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace LaravelCorrelationId\Tests\Feature\Utils;
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\App;
+use LaravelCorrelationId\CorrelationIdService;
+use LaravelCorrelationId\Tests\AbstractTest;
+use LaravelCorrelationId\Utils\GuzzleUtils;
+
+class GuzzleUtilsTest extends AbstractTest
+{
+    use WithFaker;
+
+    /**
+     * @return void
+     */
+    public function testReturnsHandlerStackInstance(): void
+    {
+        $this->assertInstanceOf(
+            HandlerStack::class,
+            GuzzleUtils::getHandlerStack()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetMiddlewareReturnsCallable(): void
+    {
+        $this->assertIsCallable(GuzzleUtils::getMiddleware());
+    }
+
+    /**
+     * @return void
+     */
+    public function testMiddlewareAddsCorrelationIdHeader(): void
+    {
+        $correlationId        = $this->faker->uuid;
+        $middleware           = GuzzleUtils::getMiddleware();
+        $correlationIdService = App::make(CorrelationIdService::class);
+        $request              = new Request(
+            'GET',
+            $this->faker->url,
+        );
+
+        $correlationIdService->setCurrentCorrelationId($correlationId);
+
+        $request = $middleware($request);
+
+        $this->assertTrue(
+            $request->hasHeader($correlationIdService->getHttpHeaderName())
+        );
+
+        $this->assertSame(
+            $correlationId,
+            $request->getHeader($correlationIdService->getHttpHeaderName())[0]
+        );
+    }
+}

--- a/tests/Stubs/CommandWithTraitStub.php
+++ b/tests/Stubs/CommandWithTraitStub.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LaravelCorrelationId\Tests\Stubs;
+
+use LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId;
+
+class CommandWithTraitStub
+{
+    use RecallsCorrelationId;
+}


### PR DESCRIPTION
This PR rewrites most of the functionality that is related to jobs.

Instead of relying on inheritance and job middlewares to save and recall the correlation ID, this PR introduces a trait as a replacement for saving the correlation ID on the job, and replaces the middleware with an event listener that listens to the `JobProcessing`  event to recall the correlation ID.

It also updates the HTTP middleware usage to include it by default in the provider itself, offloading this installation step from the user.

Additionally, it adds `GuzzleUtils` class that enables easy passing of the correlation ID to select Guzzle clients or Laravel's HTTP clients.