### PR TITLE
Automatically set correlation ID if it is null on get

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ specified in config), and appended to every log context.
 ## Installation
 
 1. Run `composer require lukaszaleckas/laravel-correlation-id`
-2. Publish `correlation_id.php` config: `php artisan vendor:publish --tag=laravel-correlation-id`
+2. (optional) Publish `correlation_id.php` config: `php artisan vendor:publish --tag=laravel-correlation-id` if you want to customize the default parameters
 3. (optional) Add `LaravelCorrelationId\Jobs\Traits\RecallsCorrelationId` trait to your jobs
 if you want correlation id to be automatically saved on job dispatch and recalled before
 it is handled / processed.

--- a/src/CorrelationIdService.php
+++ b/src/CorrelationIdService.php
@@ -7,14 +7,17 @@ use Illuminate\Support\Str;
 
 class CorrelationIdService
 {
+    private const DEFAULT_LOG_CONTEXT_KEY  = 'correlation_id';
+    private const DEFAULT_HTTP_HEADER_NAME = 'X-CORRELATION-ID';
+
     /** @var string|null */
-    private $currentCorrelationId;
+    private ?string $currentCorrelationId;
 
     /** @var string */
-    private $logContextKey;
+    private string $logContextKey;
 
     /** @var string */
-    private $httpHeaderName;
+    private string $httpHeaderName;
 
     /**
      * @return void
@@ -22,8 +25,8 @@ class CorrelationIdService
     public function __construct()
     {
         $this->currentCorrelationId = null;
-        $this->logContextKey        = config('correlation_id.log_context_key');
-        $this->httpHeaderName       = config('correlation_id.header_name');
+        $this->logContextKey        = config('correlation_id.log_context_key', self::DEFAULT_LOG_CONTEXT_KEY);
+        $this->httpHeaderName       = config('correlation_id.header_name', self::DEFAULT_HTTP_HEADER_NAME);
     }
 
     /**

--- a/src/CorrelationIdService.php
+++ b/src/CorrelationIdService.php
@@ -42,6 +42,12 @@ class CorrelationIdService
      */
     public function getCurrentCorrelationId(): ?string
     {
+        if ($this->currentCorrelationId === null) {
+            $this->setCurrentCorrelationId(
+                $this->generateCorrelationId()
+            );
+        }
+
         return $this->currentCorrelationId;
     }
 

--- a/tests/Feature/CorrelationIdServiceTest.php
+++ b/tests/Feature/CorrelationIdServiceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaravelCorrelationId\Tests\Feature;
+
+use Illuminate\Support\Facades\App;
+use LaravelCorrelationId\CorrelationIdService;
+use LaravelCorrelationId\Tests\AbstractTest;
+
+class CorrelationIdServiceTest extends AbstractTest
+{
+    /**
+     * @return void
+     */
+    public function testGetCurrentCorrelationIdSetsRandomCorrelationIdWhenItIsNull(): void
+    {
+        $correlationIdService = App::make(CorrelationIdService::class);
+
+        $correlationIdService->setCurrentCorrelationId(null);
+
+        $this->assertNotNull($correlationIdService->getCurrentCorrelationId());
+    }
+}


### PR DESCRIPTION
This PR adds default values to the `config` method in `CorrelationIdService` constructor. This should make it so publishing the configuration file is completely optional and only necessary if the default values need to be customized.

This PR also adds additional functionality to `CorrelationIdService::getCurrentCorrelationId()` so that it would generate a correlation ID if it is currently `null`